### PR TITLE
Add mutex and condition for thread synchronization

### DIFF
--- a/BlockingQueue/BlockingQueue.h
+++ b/BlockingQueue/BlockingQueue.h
@@ -1,13 +1,23 @@
 # include "QueueNode.h"
+# include <mutex>
+# include <condition_variable>
 
 struct BlockingQueue {
+    // properties
     int size; // The current size of the queue
     int maxSize; // The maximum number of elements that the queue can house.
     QueueNode* head; // The pointer to the head of the queue.
     QueueNode* tail; // the pointer to the tail of the queue.
 
+    // Synchronization
+    std::mutex mtx;
+    std::condition_variable cv;
 
-void* popleft(); // We will pop the head QueueNode and return the connection property
-QueueNode* append(void* connection); // We will take the used connection and add it back to the end of the queue.
+    // Constructor
+    BlockingQueue(int maxSize) : size(0), maxSize(maxSize), head(nullptr), tail(nullptr) {};
+
+    // Methods
+    void* popleft(); // We will pop the head QueueNode and return the connection property
+    QueueNode* append(void* connection); // We will take the used connection and add it back to the end of the queue.
 
 };

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -Wextra
+CXXFLAGS = -std=c++17 -Wall -Wextra -pthread
 
 # build test binary
 test: BlockingQueue/tests/BlockingQueueTest.cpp BlockingQueue/BlockingQueue.cpp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # connection-pooling
 Connection pooling using a blocking queue. The blocking queue will be a thread safe blocking queue.
 
-## 1. Implement FIFO queue of connections
+## 1. Implement FIFO queue of connections.
+## 2. Implement thread synchronization use mutex and condition variables for queue operations.


### PR DESCRIPTION
Add mutex and condition for thread synchronization. 
In popleft() a condition variable is used so that a thread waits if there are no connections to be popped. 
In append() mutex is used so that only a single thread can append to the queue. Additionally we also wake up one waiting thread using notify one. 

